### PR TITLE
Remove dev deps path

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   },
   "scripts": {
     "prepublish": ". ./scripts/prepublish.sh",
-    "lint": "./node_modules/.bin/eslint ./lib",
-    "lintfix": "./node_modules/.bin/eslint ./lib --fix",
-    "testonly": "./node_modules/.bin/mocha $npm_package_options_mocha",
+    "lint": "eslint ./lib",
+    "lintfix": "eslint ./lib --fix",
+    "testonly": "mocha $npm_package_options_mocha",
     "test": "npm run lint && npm run testonly"
   },
   "devDependencies": {


### PR DESCRIPTION
Dev dependency packages shouldn't need the path when using `npm run` scripts.
I tested without the path and with no global packages installed and it works fine.

Were you just being explicit? Feel free to just close my PR :smile: 
